### PR TITLE
Add extension method for task waiting with coroutines and async operations

### DIFF
--- a/Assets/UGF.RuntimeTools.Runtime.Tests/Resources.meta
+++ b/Assets/UGF.RuntimeTools.Runtime.Tests/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2fe37fa0a745596488a833c13eb869cd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.RuntimeTools.Runtime.Tests/Resources/Material_1.mat
+++ b/Assets/UGF.RuntimeTools.Runtime.Tests/Resources/Material_1.mat
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Material_1
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/UGF.RuntimeTools.Runtime.Tests/Resources/Material_1.mat.meta
+++ b/Assets/UGF.RuntimeTools.Runtime.Tests/Resources/Material_1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3aaa338911aa64447836dcb953dffcff
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.RuntimeTools.Runtime.Tests/Tasks.meta
+++ b/Assets/UGF.RuntimeTools.Runtime.Tests/Tasks.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fb3067c5cca3418a89d06799cb0d1301
+timeCreated: 1628092791

--- a/Assets/UGF.RuntimeTools.Runtime.Tests/Tasks/TestTaskExtensions.cs
+++ b/Assets/UGF.RuntimeTools.Runtime.Tests/Tasks/TestTaskExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UGF.RuntimeTools.Runtime.Tasks;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace UGF.RuntimeTools.Runtime.Tests.Tasks
+{
+    public class TestTaskExtensions
+    {
+        [UnityTest]
+        public IEnumerator WaitCoroutine()
+        {
+            Task<int> task = TestWaitCoroutineAsync();
+
+            yield return task.WaitCoroutine();
+
+            int result = task.Result;
+
+            Assert.AreEqual(10, result);
+        }
+
+        [UnityTest]
+        public IEnumerator WaitAsyncOperation()
+        {
+            Task<Object> task = Resources.LoadAsync<Material>("Material_1").WaitAsync();
+
+            yield return task.WaitCoroutine();
+
+            Object result = task.Result;
+
+            Assert.NotNull(result);
+            Assert.IsInstanceOf<Material>(result);
+            Assert.AreEqual("Material_1", result.name);
+        }
+
+        private async Task<int> TestWaitCoroutineAsync()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await Task.Yield();
+            }
+
+            return 10;
+        }
+    }
+}

--- a/Assets/UGF.RuntimeTools.Runtime.Tests/Tasks/TestTaskExtensions.cs.meta
+++ b/Assets/UGF.RuntimeTools.Runtime.Tests/Tasks/TestTaskExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d79d79fd18ca4e34a630fee8230a93e3
+timeCreated: 1628092794

--- a/Packages/UGF.RuntimeTools/Runtime/Tasks.meta
+++ b/Packages/UGF.RuntimeTools/Runtime/Tasks.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4454902535a64cda9089d68fdce1be0b
+timeCreated: 1628091870

--- a/Packages/UGF.RuntimeTools/Runtime/Tasks/TaskExtensions.cs
+++ b/Packages/UGF.RuntimeTools/Runtime/Tasks/TaskExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections;
+using System.Threading.Tasks;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace UGF.RuntimeTools.Runtime.Tasks
+{
+    public static class TaskExtensions
+    {
+        public static IEnumerator WaitCoroutine(this Task task)
+        {
+            if (task == null) throw new ArgumentNullException(nameof(task));
+
+            while (!task.IsCompleted)
+            {
+                yield return null;
+            }
+
+            if (task.IsFaulted)
+            {
+                throw task.Exception ?? new Exception("Task has faulted.");
+            }
+        }
+
+        public static async Task WaitAsync(this AsyncOperation operation)
+        {
+            if (operation == null) throw new ArgumentNullException(nameof(operation));
+
+            while (!operation.isDone)
+            {
+                await Task.Yield();
+            }
+        }
+
+        public static async Task<Object> WaitAsync(this ResourceRequest request)
+        {
+            if (request == null) throw new ArgumentNullException(nameof(request));
+
+            while (!request.isDone)
+            {
+                await Task.Yield();
+            }
+
+            return request.asset ? request.asset : throw new NullReferenceException("Result of resource request is null.");
+        }
+    }
+}

--- a/Packages/UGF.RuntimeTools/Runtime/Tasks/TaskExtensions.cs.meta
+++ b/Packages/UGF.RuntimeTools/Runtime/Tasks/TaskExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6b1bcb08cb274dc7b4173182ebd53ed9
+timeCreated: 1628091874

--- a/Packages/UGF.RuntimeTools/package.json
+++ b/Packages/UGF.RuntimeTools/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.runtimetools",
   "displayName": "UGF.RuntimeTools",
   "version": "2.2.0",
-  "unity": "2020.2",
+  "unity": "2020.3",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Provides tools for working with runtime code.",
   "author": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.9f1
-m_EditorVersionWithRevision: 2020.3.9f1 (108be757e447)
+m_EditorVersion: 2020.3.14f1
+m_EditorVersionWithRevision: 2020.3.14f1 (d0d1bb862f9d)


### PR DESCRIPTION
- Update package _Unity_ version up to `2020.3`.
- Add `TaskExtensions.WaitCoroutine()` extension method for `Task` class, used to wait for task inside of coroutine.
- Add `TaskExtensions.WaitAsync()` extension method for `AsyncOperation` class, used to wait for async operation inside of async/await context.
- Add `TaskExtensions.WaitAsync()` extension method for `ResourceRequest` class, used to wait for request inside of async/await context.