### PR TITLE
Add context value scope

### DIFF
--- a/Packages/UGF.RuntimeTools/Runtime/Contexts/ContextValueScope.cs
+++ b/Packages/UGF.RuntimeTools/Runtime/Contexts/ContextValueScope.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace UGF.RuntimeTools.Runtime.Contexts
+{
+    public readonly struct ContextValueScope : IDisposable
+    {
+        public IContext Context { get; }
+        public object Value { get; }
+
+        public ContextValueScope(IContext context, object value)
+        {
+            Context = context ?? throw new ArgumentNullException(nameof(context));
+            Value = value ?? throw new ArgumentNullException(nameof(value));
+
+            Context.Add(Value);
+        }
+
+        public void Dispose()
+        {
+            Context.Remove(Value);
+        }
+    }
+}

--- a/Packages/UGF.RuntimeTools/Runtime/Contexts/ContextValueScope.cs.meta
+++ b/Packages/UGF.RuntimeTools/Runtime/Contexts/ContextValueScope.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6a9ab369dbeb4b90ab429b4177d15321
+timeCreated: 1640780843

--- a/Packages/UGF.RuntimeTools/package.json
+++ b/Packages/UGF.RuntimeTools/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.runtimetools",
   "displayName": "UGF.RuntimeTools",
   "version": "2.4.0",
-  "unity": "2020.3",
+  "unity": "2021.2",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Provides tools for working with runtime code.",
   "author": {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.7",
+    "com.unity.ide.rider": "3.0.9",
     "com.unity.test-framework": "1.1.30",
     "com.unity.test-framework.performance": "2.8.0-preview"
   },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -14,7 +14,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.7",
+      "version": "3.0.9",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/MemorySettings.asset
+++ b/ProjectSettings/MemorySettings.asset
@@ -1,0 +1,35 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!387306366 &1
+MemorySettings:
+  m_ObjectHideFlags: 0
+  m_EditorMemorySettings:
+    m_MainAllocatorBlockSize: -1
+    m_ThreadAllocatorBlockSize: -1
+    m_MainGfxBlockSize: -1
+    m_ThreadGfxBlockSize: -1
+    m_CacheBlockSize: -1
+    m_TypetreeBlockSize: -1
+    m_ProfilerBlockSize: -1
+    m_ProfilerEditorBlockSize: -1
+    m_BucketAllocatorGranularity: -1
+    m_BucketAllocatorBucketsCount: -1
+    m_BucketAllocatorBlockSize: -1
+    m_BucketAllocatorBlockCount: -1
+    m_ProfilerBucketAllocatorGranularity: -1
+    m_ProfilerBucketAllocatorBucketsCount: -1
+    m_ProfilerBucketAllocatorBlockSize: -1
+    m_ProfilerBucketAllocatorBlockCount: -1
+    m_TempAllocatorSizeMain: -1
+    m_JobTempAllocatorBlockSize: -1
+    m_BackgroundJobTempAllocatorBlockSize: -1
+    m_JobTempAllocatorReducedBlockSize: -1
+    m_TempAllocatorSizeGIBakingWorker: -1
+    m_TempAllocatorSizeNavMeshWorker: -1
+    m_TempAllocatorSizeAudioWorker: -1
+    m_TempAllocatorSizeCloudWorker: -1
+    m_TempAllocatorSizeGfx: -1
+    m_TempAllocatorSizeJobWorker: -1
+    m_TempAllocatorSizeBackgroundWorker: -1
+    m_TempAllocatorSizePreloadManager: -1
+  m_PlatformMemorySettings: {}

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.16f1
-m_EditorVersionWithRevision: 2020.3.16f1 (049d6eca3c44)
+m_EditorVersion: 2021.2.4f1
+m_EditorVersionWithRevision: 2021.2.4f1 (99ba6aa4c552)


### PR DESCRIPTION
- Update package _Unity_ version to `2021.2`.
- Add `ContextValueScope` structure to define scope when value available in context.